### PR TITLE
Update FontInfo.swift for Ventura

### DIFF
--- a/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
+++ b/ProfileCreator/ProfileCreator/Utility/FontInfo.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Erik Berglund. All rights reserved.
 //
 
+import CoreGraphics
+import CoreText
 import Foundation
 
 struct FontInformation {


### PR DESCRIPTION
CoreGraphics and CoreText are needed for some font and graphic classes.